### PR TITLE
Modified template variable in ConfigMap

### DIFF
--- a/yaml/cfgmap.yaml
+++ b/yaml/cfgmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: eks-saga
 data:
   TZ: "timeZone"
-  REGION: "ap-south-1"
+  REGION: "regionId"
   DBHOST: "dbEndpoint"
   DBPORT: "3306"
   DBUSER: "pod_user"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- `ConfigMap` uses template variable `regionId` for AWS region ID.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
